### PR TITLE
docs(keywords): minor formatting fix

### DIFF
--- a/helpers/VOCABOLARIO.md
+++ b/helpers/VOCABOLARIO.md
@@ -38,7 +38,7 @@
 - **RDBMS (Relational Database Management System)**: Un tipo di DBMS che organizza i dati in tabelle relazionali e utilizza il linguaggio SQL per interrogare e manipolare i dati.
 - **Indice**: Indica una struttura di dati che migliora l'efficienza delle query, accelerando la ricerca e il recupero delle informazioni all'interno di un database.
 - **Indexing**: Il processo di creazione di indici per migliorare le prestazioni delle query database.
-- **Normalizzazione**: Processo di organizzazione e progettazione di una struttura dati in modo efficiente, riducendo la ridondanza delle informazioni e migliorando la coerenza dei dati. 
+- **Normalizzazione**: Processo di organizzazione e progettazione di una struttura dati in modo efficiente, riducendo la ridondanza delle informazioni e migliorando la coerenza dei dati.
 
 # Controllo Versione
 
@@ -77,7 +77,8 @@
 
 # Sicurezza
 
-- **Crittografia**: Conversione dei dati da un formato leggibile in un formato codificato che può essere letto o elaborato solo dopo che è stato,La crittografia è usata in molte applicazioni come le carte per le transazioni bancarie, le password dei computer e le transazioni di commercio elettronico. -**Cybersecurity**: Insieme di tecnologie, processi e misure di protezione progettate per ridurre il rischio di attacchi informatici.
+- **Crittografia**: Conversione dei dati da un formato leggibile in un formato codificato che può essere letto o elaborato solo dopo che è stato,La crittografia è usata in molte applicazioni come le carte per le transazioni bancarie, le password dei computer e le transazioni di commercio elettronico.
+-**Cybersecurity**: Insieme di tecnologie, processi e misure di protezione progettate per ridurre il rischio di attacchi informatici.
 - **Autenticazione e Autorizzazione**: Processi che controllano chi può accedere a un sistema o a una risorsa e cosa può fare.
 - **Firewall**: Dispositivo di sicurezza che monitora e controlla il traffico di rete.
 - **Penetration Testing**: Attività mirata a testare la sicurezza di un sistema simulando attacchi reali per identificare vulnerabilità.


### PR DESCRIPTION

## Descrizione

_Per favore, includi un riepilogo delle modifiche e dei problemi risolti_

I fixed the two keywords 'Crittografia' and 'Cybersecurity' on two different lines

## Domande/commenti per il revisore

_Per favore, indica se ci sono cose di cui essere consapevoli o di cui hai bisogno di input_

Even if I used `Save Without Formatting` `⌘ + K, S` it still automatically trims trailing whitespace at the end of one line 'Normalizzazione'. 
I've even just unchecked these VS Code settings: 

- `Files: Trim Trailing Whitespace` 
- `Editor: Trim Auto Whitespace` 
- `Editor > Smart Select: Select Leading And Trailing Whitespace`, 
+ plus switched `SCM: Diff Decoration Ignore Trim Whitespace` to `true`

but nothing worked out. IDK, it might be a default behaviour of my VS Code on macOS.


## Tipo di modifica - seleziona il tipo di modifica pertinente:

- [X] 🐛 Risoluzione di bug (modifica non critica che risolve un problema)
- [ ] 🆕 Nuova funzionalità (modifica non critica che aggiunge funzionalità)
- [ ] 💄 Regolazione (regolazione visuale o semplici aggiustamenti logici)
- [ ] 💥 Modifica critica (correzioni o funzionalità che potrebbero causare problemi alle esistenti)

## Testato su - seleziona il tipo di dispositivo pertinente:

- [ ] Chrome
- [ ] Firefox
- [ ] Brave

## Come testare - includi un elenco di cose da testare

_Includi collegamenti o altri modi per individuare facilmente i dati di test_

### Screenshots, registrazioni video 📸 👇

_Includi un video in formato GIF. Per Mac puoi utilizzare [GetKap](https://getkap.co/)_
